### PR TITLE
added Sentinel from jupyter_nbformat

### DIFF
--- a/nbstripout.py
+++ b/nbstripout.py
@@ -70,6 +70,23 @@ except ImportError:
         def write(nb, f):
             return current.write(nb, f, 'json')
 
+        class Sentinel(object):
+
+            def __init__(self, name, module, docstring=None):
+                self.name = name
+                self.module = module
+                if docstring:
+                    self.__doc__ = docstring
+
+
+            def __repr__(self):
+                return str(self.module)+'.'+self.name
+
+        NO_CONVERT = Sentinel('NO_CONVERT', __name__,
+                              """Value to prevent nbformat to convert notebooks to most recent version.                                                                                                              
+                              """)
+
+
 
 def _cells(nb):
     """Yield all cells in an nbformat-insensitive manner"""


### PR DESCRIPTION
This supports older systems running IPython (without this change, we get a NameError bc NO_CONVERT is not defined).

Sentinel is defined in: https://github.com/jupyter/nbformat/blob/616df84f257db4181b9eba2851d300cfb76ed90e/jupyter_nbformat/sentinel.py
